### PR TITLE
fix/annoying-closing-of-trello-card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,62 +1,92 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 - Add support for starting/stopping a timer
 - Show hours as HH:MM or decimal in the Bubble, depending on setting in MOCO
 
-
 ## [1.0.18] - 2019-03-23
+
 ### Added
+
 - First release of version 1
 
 ## [1.0.19] - 2019-03-26
+
 ### Changed
+
 - Position Bubble in the bottom right by default
 
 ### Fixed
+
 - Set default value of subdomain to `__unset__` to prevent network error if it is empty
 
 ## [1.0.20] - 2019-03-26
+
 ### Added
+
 - Add support for tags in description
 
 ## [1.0.21] - 2019-03-26
+
 ### Changed
+
 - Update README with example configuration and instructions for local installation
 
 ## [1.0.22] - 2019-03-28
+
 ### Changed
+
 - Change the default value of subdomain to `unset` to have a well-formed URL.
 
 ## [1.1.0] - 2019-03-30
+
 ### Added
+
 - Read project identifier from Asana project title
 - Add support for meistertask.com
 
 ### Fixed
+
 - Link logo in modal to MOCO activities page
 - Set full url on service, including query params
 
 ## [1.1.1] - 2019-04-01
+
 ### Fixed
+
 - Discard projects with undefined identifier for preselecting
 
 ## [1.1.2] - 2019-04-06
+
 ### Fixed
+
 - Allow production build without BUGSNAG_API_KEY
 - Hours entered in brackets must be non-billable
 
 ### Changed
+
 - Read project identifier also from card title in the meistertask service
 
 ## [1.1.3] - 2019-04-10
+
 ### Fixed
+
 - Read projected identifier in Asana's "My tasks"-view
 
 ## [1.1.4] - 2019-04-11
+
 ### Added
+
 - Show customer name in the project select box
+
+## [1.1.5] - 2019-04-24
+
+### Fixed
+
+- Unexpected closing of Trello card when clicking on Bubble

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,39 +10,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for starting/stopping a timer
 - Show hours as HH:MM or decimal in the Bubble, depending on setting in MOCO
 
-## [1.0.18] - 2019-03-23
-
-### Added
-
-- First release of version 1
-
-## [1.0.19] - 2019-03-26
-
-### Changed
-
-- Position Bubble in the bottom right by default
+## [1.1.5] - 2019-04-24
 
 ### Fixed
 
-- Set default value of subdomain to `__unset__` to prevent network error if it is empty
+- Unexpected closing of Trello card when clicking on Bubble
 
-## [1.0.20] - 2019-03-26
+## [1.1.4] - 2019-04-11
 
 ### Added
 
-- Add support for tags in description
+- Show customer name in the project select box
 
-## [1.0.21] - 2019-03-26
+## [1.1.3] - 2019-04-10
+
+### Fixed
+
+- Read projected identifier in Asana's "My tasks"-view
+
+## [1.1.2] - 2019-04-06
+
+### Fixed
+
+- Allow production build without BUGSNAG_API_KEY
+- Hours entered in brackets must be non-billable
 
 ### Changed
 
-- Update README with example configuration and instructions for local installation
+- Read project identifier also from card title in the meistertask service
 
-## [1.0.22] - 2019-03-28
+## [1.1.1] - 2019-04-01
 
-### Changed
+### Fixed
 
-- Change the default value of subdomain to `unset` to have a well-formed URL.
+- Discard projects with undefined identifier for preselecting
 
 ## [1.1.0] - 2019-03-30
 
@@ -56,37 +57,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Link logo in modal to MOCO activities page
 - Set full url on service, including query params
 
-## [1.1.1] - 2019-04-01
-
-### Fixed
-
-- Discard projects with undefined identifier for preselecting
-
-## [1.1.2] - 2019-04-06
-
-### Fixed
-
-- Allow production build without BUGSNAG_API_KEY
-- Hours entered in brackets must be non-billable
+## [1.0.22] - 2019-03-28
 
 ### Changed
 
-- Read project identifier also from card title in the meistertask service
+- Change the default value of subdomain to `unset` to have a well-formed URL.
 
-## [1.1.3] - 2019-04-10
+## [1.0.21] - 2019-03-26
 
-### Fixed
+### Changed
 
-- Read projected identifier in Asana's "My tasks"-view
+- Update README with example configuration and instructions for local installation
 
-## [1.1.4] - 2019-04-11
+## [1.0.20] - 2019-03-26
 
 ### Added
 
-- Show customer name in the project select box
+- Add support for tags in description
 
-## [1.1.5] - 2019-04-24
+## [1.0.19] - 2019-03-26
+
+### Changed
+
+- Position Bubble in the bottom right by default
 
 ### Fixed
 
-- Unexpected closing of Trello card when clicking on Bubble
+- Set default value of subdomain to `__unset__` to prevent network error if it is empty
+
+## [1.0.18] - 2019-03-23
+
+### Added
+
+- First release of version 1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "moco-browser-extensions",
   "description": "Browser plugin for MOCO",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "license": "MIT",
   "scripts": {
     "start": "yarn start:chrome",

--- a/src/js/components/Bubble.js
+++ b/src/js/components/Bubble.js
@@ -12,11 +12,11 @@ const Bubble = ({ bookedHours }) => (
 )
 
 Bubble.propTypes = {
-  bookedHours: PropTypes.number
+  bookedHours: PropTypes.number,
 }
 
 Bubble.defaultProps = {
-  bookedHours: 0
+  bookedHours: 0,
 }
 
 export default Bubble


### PR DESCRIPTION
The fix consists of moving the click listener from the bubble to the document using capturing (in order to make sure we are the first handling the event).