### PR TITLE
feature/strip-identifier

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,7 @@
   "plugins": [
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
     ["@babel/plugin-proposal-class-properties", { "loose": true }],
-    ["@babel/plugin-proposal-optional-chaining"]
+    "@babel/plugin-proposal-optional-chaining",
+    "@babel/plugin-proposal-nullish-coalescing-operator"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@babel/core": "^7.2.2",
     "@babel/plugin-proposal-class-properties": "^7.2.2",
     "@babel/plugin-proposal-decorators": "^7.2.2",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
     "@babel/plugin-proposal-optional-chaining": "^7.2.0",
     "@babel/preset-env": "^7.2.2",
     "@babel/preset-react": "^7.0.0",

--- a/src/js/remoteServices.js
+++ b/src/js/remoteServices.js
@@ -11,28 +11,23 @@ export default {
       document.querySelector(".ItemRow--highlighted textarea")?.textContent?.trim() ||
       document.querySelector(".ItemRow--focused textarea")?.textContent?.trim() ||
       document.querySelector(".SingleTaskPane textarea")?.textContent?.trim(),
-    projectId: document => {
-      const match = document
+    projectId: document =>
+      document
         .querySelector(".TaskProjectPill-projectName")
         ?.textContent?.trim()
-        ?.match(projectRegex)
-      return match && match[1]
-    },
+        ?.match(projectRegex)?.[1],
   },
 
   "github-pr": {
     name: "github",
     urlPatterns: ["https\\://github.com/:org/:repo/pull/:id(/:tab)"],
     id: (document, service, { org, repo, id }) => [service.key, org, repo, id].join("."),
-    description: (document, service, { org, repo, id }) =>
-      document.querySelector(".js-issue-title")?.textContent?.trim(),
-    projectId: document => {
-      const match = document
+    description: document => document.querySelector(".js-issue-title")?.textContent?.trim(),
+    projectId: document =>
+      document
         .querySelector(".js-issue-title")
         ?.textContent.trim()
-        ?.match(projectRegex)
-      return match && match[1]
-    },
+        ?.match(projectRegex)?.[1],
   },
 
   "github-issue": {
@@ -107,13 +102,11 @@ export default {
       id: ["t", "ot"],
     },
     description: document => document.querySelector(".title-field-ghost")?.textContent?.trim(),
-    projectId: document => {
-      const match = document
+    projectId: document =>
+      document
         .querySelector(".header-title__main")
         ?.textContent?.trim()
-        ?.match(projectRegex)
-      return match && match[1]
-    },
+        ?.match(projectRegex)?.[1],
   },
 
   wunderlist: {

--- a/src/js/remoteServices.js
+++ b/src/js/remoteServices.js
@@ -36,6 +36,11 @@ export default {
     id: (document, service, { org, repo, id }) => [service.key, org, repo, id].join("."),
     description: (document, service, { org, repo, id }) =>
       document.querySelector(".js-issue-title")?.textContent?.trim(),
+    projectId: document =>
+      document
+        .querySelector(".js-issue-title")
+        ?.textContent?.trim()
+        ?.match(projectRegex)?.[1],
   },
 
   jira: {
@@ -82,12 +87,22 @@ export default {
     urlPatterns: ["https\\://trello.com/c/:id/:title"],
     description: (document, service, { title }) =>
       document.querySelector(".js-title-helper")?.textContent?.trim() || title,
+    projectId: document =>
+      document
+        .querySelector(".js-title-helper")
+        ?.textContent?.trim()
+        ?.match(projectRegex)?.[1],
   },
 
   youtrack: {
     name: "youtrack",
     urlPatterns: ["https\\://:org.myjetbrains.com/youtrack/issue/:id"],
     description: document => document.querySelector("yt-issue-body h1")?.textContent?.trim(),
+    projectId: document =>
+      document
+        .querySelector("yt-issue-body h1")
+        ?.textContent?.trim()
+        ?.match(projectRegex)?.[1],
   },
 
   wrike: {
@@ -116,5 +131,10 @@ export default {
       document
         .querySelector(".taskItem.selected .taskItem-titleWrapper-title")
         ?.textContent?.trim(),
+    projectId: document =>
+      document
+        .querySelector(".taskItem.selected .taskItem-titleWrapper-title")
+        ?.textContent?.trim()
+        ?.match(projectRegex)?.[1],
   },
 }

--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -23,6 +23,7 @@ export const ERROR_UNKNOWN = "unknown"
 
 export const noop = () => null
 export const asArray = input => (Array.isArray(input) ? input : [input])
+export const removeNonAlphanumChars = input => String(input ?? "").replace(/[\W_]/g, "")
 
 export const findProjectBy = prop => val => projects => {
   if (!val) {
@@ -30,7 +31,11 @@ export const findProjectBy = prop => val => projects => {
   }
 
   return compose(
-    find(pathEq(prop, val)),
+    find(
+      project =>
+        project[prop] === val ||
+        removeNonAlphanumChars(project[prop]) === removeNonAlphanumChars(val),
+    ),
     flatMap(get("options")),
   )(projects)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -280,6 +280,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-json-strings" "^7.2.0"
 
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.4.4.tgz#41c360d59481d88e0ce3a3f837df10121a769b39"
+  integrity sha512-Amph7Epui1Dh/xxUxS2+K22/MUi6+6JVTvy3P58tja3B6yKTSjwwx0/d83rF7551D6PVSSoplQb8GCwqec7HRw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.2.0"
+
 "@babel/plugin-proposal-object-rest-spread@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz#61939744f71ba76a3ae46b5eea18a54c16d22e58"
@@ -345,6 +353,13 @@
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz#0b85a3b4bc7cdf4cc4b8bf236335b907ca22e7c7"
   integrity sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-nullish-coalescing-operator@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.2.0.tgz#f75083dfd5ade73e783db729bbd87e7b9efb7624"
+  integrity sha512-lRCEaKE+LTxDQtgbYajI04ddt6WW0WJq57xqkAZ+s11h4YgfRHhVA/Y2VhfPzzFD4qeLHWg32DMp9HooY4Kqlg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 


### PR DESCRIPTION
Jira disallows non-alphanumeric chars in the project key. We compare the Jira project key with the MOCO project identifier for pre-selecting the right project in the activity form.

![jira-projekt-key](https://user-images.githubusercontent.com/871953/66493834-05478a00-eab7-11e9-982f-0b9365da991c.png)


If the project identifier in MOCO contained special chars like dashes, a match is not possible.

With this PR, project key and project identifier are also compared ignoring non-alphanumeric characters.