### PR TITLE
fix/focus-timer-view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.1] - 2019-10-17
 
-- Add support for starting/stopping a timer
-- Show hours as HH:MM or decimal in the Bubble, depending on setting in MOCO
+### Fixed
+
+- Set propper focus on timer view
+
+### Removed
+
+- Find projects by identifier without alphanumerical characters
 
 ## [1.3.0] - 2019-10-11
 
-### Changed
+### Added
 
 - Start a new timer or stop a running timer
 - Format time as set in time tracking

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "moco-browser-extensions",
   "description": "Browser plugin for MOCO",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "scripts": {
     "start": "yarn start:chrome",

--- a/src/js/components/App/TimerView.js
+++ b/src/js/components/App/TimerView.js
@@ -25,7 +25,7 @@ export default function TimerView({ timedActivity, onStopTimer }) {
         offset={timedActivity.seconds}
         style={{ fontSize: "36px", display: "inline-block" }}
       />
-      <button className="moco-bx-btn btn-stop-timer" onClick={handleStopTimer}>
+      <button className="moco-bx-btn btn-stop-timer" onClick={handleStopTimer} autoFocus>
         <StopWatch />
       </button>
     </div>

--- a/src/js/components/Popup.js
+++ b/src/js/components/Popup.js
@@ -19,13 +19,6 @@ const Popup = forwardRef((props, ref) => {
   }
 
   useEffect(() => {
-    // Document might lose focus when clicking the browser action.
-    // Document might be out of focus when hitting the shortcut key.
-    // This puts the focus back to the document and ensures that:
-    // - the autofocus on the hours input field is triggered
-    // - the ESC key closes the popup without closing anything else
-    window.focus()
-    document.activeElement?.blur()
     window.addEventListener("message", handleMessage)
     return () => {
       window.removeEventListener("message", handleMessage)

--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -25,7 +25,6 @@ export const ERROR_UNKNOWN = "unknown"
 
 export const noop = () => null
 export const asArray = input => (Array.isArray(input) ? input : [input])
-export const removeNonAlphanumChars = input => String(input ?? "").replace(/[\W_]/g, "")
 
 export const findProjectBy = prop => val => projects => {
   if (!val) {
@@ -33,11 +32,7 @@ export const findProjectBy = prop => val => projects => {
   }
 
   return compose(
-    find(
-      project =>
-        project[prop] === val ||
-        removeNonAlphanumChars(project[prop]) === removeNonAlphanumChars(val),
-    ),
+    find(pathEq(prop, val)),
     flatMap(get("options")),
   )(projects)
 }


### PR DESCRIPTION
Currently, the timer view is not focuesd. The Trello-card instead of the timer view is closed when hitting ESC.

Revert find projects with more than alphanumerical characters.