### PR TITLE
feature/project-identifier-in-trello-board-title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2019-10-24
+
+### Added
+
+- Read project identifier from Trello board title
+
 ## [1.3.1] - 2019-10-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "moco-browser-extensions",
   "description": "Browser plugin for MOCO",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "scripts": {
     "start": "yarn start:chrome",

--- a/src/js/remoteServices.js
+++ b/src/js/remoteServices.js
@@ -91,6 +91,10 @@ export default {
       document
         .querySelector(".js-title-helper")
         ?.textContent?.trim()
+        ?.match(projectRegex)?.[1] ||
+      document
+        .querySelector(".js-board-editing-target")
+        ?.textContent?.trim()
         ?.match(projectRegex)?.[1],
   },
 

--- a/src/js/remoteServices.js
+++ b/src/js/remoteServices.js
@@ -1,5 +1,11 @@
 const projectRegex = /\[([\w-]+)\]/
 
+const projectIdentifierBySelector = selector => document =>
+  document
+    .querySelector(selector)
+    ?.textContent?.trim()
+    ?.match(projectRegex)?.[1]
+
 export default {
   asana: {
     name: "asana",
@@ -11,11 +17,7 @@ export default {
       document.querySelector(".ItemRow--highlighted textarea")?.textContent?.trim() ||
       document.querySelector(".ItemRow--focused textarea")?.textContent?.trim() ||
       document.querySelector(".SingleTaskPane textarea")?.textContent?.trim(),
-    projectId: document =>
-      document
-        .querySelector(".TaskProjectPill-projectName")
-        ?.textContent?.trim()
-        ?.match(projectRegex)?.[1],
+    projectId: projectIdentifierBySelector(".TaskProjectPill-projectName"),
   },
 
   "github-pr": {
@@ -23,11 +25,7 @@ export default {
     urlPatterns: ["https\\://github.com/:org/:repo/pull/:id(/:tab)"],
     id: (document, service, { org, repo, id }) => [service.key, org, repo, id].join("."),
     description: document => document.querySelector(".js-issue-title")?.textContent?.trim(),
-    projectId: document =>
-      document
-        .querySelector(".js-issue-title")
-        ?.textContent.trim()
-        ?.match(projectRegex)?.[1],
+    projectId: projectIdentifierBySelector(".js-issue-title"),
   },
 
   "github-issue": {
@@ -36,11 +34,7 @@ export default {
     id: (document, service, { org, repo, id }) => [service.key, org, repo, id].join("."),
     description: (document, service, { org, repo, id }) =>
       document.querySelector(".js-issue-title")?.textContent?.trim(),
-    projectId: document =>
-      document
-        .querySelector(".js-issue-title")
-        ?.textContent?.trim()
-        ?.match(projectRegex)?.[1],
+    projectId: projectIdentifierBySelector(".js-issue-title"),
   },
 
   jira: {
@@ -88,25 +82,15 @@ export default {
     description: (document, service, { title }) =>
       document.querySelector(".js-title-helper")?.textContent?.trim() || title,
     projectId: document =>
-      document
-        .querySelector(".js-title-helper")
-        ?.textContent?.trim()
-        ?.match(projectRegex)?.[1] ||
-      document
-        .querySelector(".js-board-editing-target")
-        ?.textContent?.trim()
-        ?.match(projectRegex)?.[1],
+      projectIdentifierBySelector(".js-title-helper")(document) ||
+      projectIdentifierBySelector(".js-board-editing-target")(document),
   },
 
   youtrack: {
     name: "youtrack",
     urlPatterns: ["https\\://:org.myjetbrains.com/youtrack/issue/:id"],
     description: document => document.querySelector("yt-issue-body h1")?.textContent?.trim(),
-    projectId: document =>
-      document
-        .querySelector("yt-issue-body h1")
-        ?.textContent?.trim()
-        ?.match(projectRegex)?.[1],
+    projectId: projectIdentifierBySelector("yt-issue-body h1"),
   },
 
   wrike: {
@@ -121,11 +105,7 @@ export default {
       id: ["t", "ot"],
     },
     description: document => document.querySelector(".title-field-ghost")?.textContent?.trim(),
-    projectId: document =>
-      document
-        .querySelector(".header-title__main")
-        ?.textContent?.trim()
-        ?.match(projectRegex)?.[1],
+    projectId: projectIdentifierBySelector(".header-title__main"),
   },
 
   wunderlist: {
@@ -135,10 +115,6 @@ export default {
       document
         .querySelector(".taskItem.selected .taskItem-titleWrapper-title")
         ?.textContent?.trim(),
-    projectId: document =>
-      document
-        .querySelector(".taskItem.selected .taskItem-titleWrapper-title")
-        ?.textContent?.trim()
-        ?.match(projectRegex)?.[1],
+    projectId: projectIdentifierBySelector(".taskItem.selected .taskItem-titleWrapper-title"),
   },
 }


### PR DESCRIPTION
This PR update the Trello remote service to also read the project identifier from the board title. So far, the project identifier was only read from the Trello-card. The project identifier in the card title prevails if it a project identifier is also defined on the board title.

This PR also includes a refactoring extracting the common use-case of reading a project identifier from a node by a css-selector.