### PR TITLE
fix/trello-and-asana

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 019-10-17
+
+### Fixed
+
+- Fix an issue on Trello where the card closes when clicking the MOCO bubble
+- Asana: read project title from page heading
+
 ## [1.3.2] - 2019-10-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "moco-browser-extensions",
   "description": "Browser plugin for MOCO",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "license": "MIT",
   "scripts": {
     "start": "yarn start:chrome",

--- a/src/js/api/Client.js
+++ b/src/js/api/Client.js
@@ -5,7 +5,7 @@ const baseURL = subdomain => {
   if (process.env.NODE_ENV === "production") {
     return `https://${encodeURIComponent(subdomain)}.mocoapp.com/api/browser_extensions`
   } else {
-    return `http://${encodeURIComponent(subdomain)}.mocoapp.localhost:3001/api/browser_extensions`
+    return `http://${encodeURIComponent(subdomain)}.mocoapp.localhost:3000/api/browser_extensions`
   }
 }
 

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -22,7 +22,7 @@ chrome.runtime.onConnect.addListener(function(port) {
   }
   port.onDisconnect.addListener(() => {
     messenger.stop()
-    document.removeEventListener("click", clickHandler, true)
+    window.removeEventListener("click", clickHandler, true)
   })
 
   function updateBubble({ service, bookedSeconds, settingTimeTrackingHHMM, timedActivity } = {}) {
@@ -30,7 +30,7 @@ chrome.runtime.onConnect.addListener(function(port) {
       const domRoot = document.createElement("div")
       domRoot.setAttribute("id", "moco-bx-root")
       document.body.appendChild(domRoot)
-      document.addEventListener("click", clickHandler, true)
+      window.addEventListener("click", clickHandler, true)
     }
 
     ReactDOM.render(

--- a/src/js/remoteServices.js
+++ b/src/js/remoteServices.js
@@ -17,7 +17,7 @@ export default {
       document.querySelector(".ItemRow--highlighted textarea")?.textContent?.trim() ||
       document.querySelector(".ItemRow--focused textarea")?.textContent?.trim() ||
       document.querySelector(".SingleTaskPane textarea")?.textContent?.trim(),
-    projectId: projectIdentifierBySelector(".TaskProjectPill-projectName"),
+    projectId: projectIdentifierBySelector(".TopbarPageHeaderStructure-titleRow h1"),
   },
 
   "github-pr": {


### PR DESCRIPTION
This PR solves an issue on Trello, where the card is closed after the MOCO bubble has been clicked.

Also, the project title is read from the page heading in asana which should make it more robust:
![Screenshot 2019-12-10 at 20 04 20](https://user-images.githubusercontent.com/871953/70560228-7fb08b00-1b88-11ea-9041-16b8a6f0d345.png)
