### PR TITLE
DRAFT: Introduce Custom Pattern

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -8,15 +8,20 @@ import remoteServices from "./remoteServices"
 import { ContentMessenger } from "utils/messaging"
 import "../css/content.scss"
 import { getSettings } from "./utils/browser"
+import { customPatterReader } from "./customPattern"
 
 const popupRef = createRef()
 
 let findService
 getSettings().then((settings) => {
-  findService = createServiceFinder(remoteServices, settings.hostOverrides)(document)
+  let services = remoteServices
+  customPatterReader().forEach((entry) => {
+    services = { ...entry, ...services }
+  })
+  findService = createServiceFinder(services, settings.hostOverrides)(document)
 })
 
-chrome.runtime.onConnect.addListener(function (port) {
+chrome.runtime.onConnect.addListener(function(port) {
   const messenger = new ContentMessenger(port)
 
   function clickHandler(event) {
@@ -25,6 +30,7 @@ chrome.runtime.onConnect.addListener(function (port) {
       messenger.postMessage({ type: "togglePopup" })
     }
   }
+
   port.onDisconnect.addListener(() => {
     messenger.stop()
     window.removeEventListener("click", clickHandler, true)

--- a/src/js/customPattern.js
+++ b/src/js/customPattern.js
@@ -1,0 +1,92 @@
+const json = require("./test.json")
+
+const formateRegex = /:(\b[^\d\W]+\b)/g
+const projectIdRegex = /P\d{5}/gm
+
+function buildQuerySelector(query, queryFunctions) {
+  const name = `${query.name}`
+  const selector = query.selector
+  const selectorFunction = (param, document) => {
+    return document.querySelector(param)?.textContent?.trim()
+  }
+  queryFunctions.push({ selectorFunction, param: selector, name })
+}
+
+function getDescription(entry, queryFunctions, document, urlParams) {
+  let result = entry.descriptionFormat
+  let m
+  while ((m = formateRegex.exec(entry.descriptionFormat)) !== null) {
+    if (m.index === formateRegex.lastIndex) {
+      formateRegex.lastIndex++
+    }
+    let erg = queryFunctions.find((value) => value.name === m[1])
+    if (erg) {
+      result = result.replace(m[0], erg.selectorFunction(erg.param, document))
+    } else {
+      result = result.replace(m[0], urlParams[m[1]])
+    }
+  }
+  return result
+}
+
+function buildService(
+  name,
+  host,
+  urlPatterns,
+  descriptionFormat,
+  allowHostOverride,
+  queryFunctions,
+  urlParams,
+  projectId,
+) {
+  projectId = projectId
+    ? projectId.selectorFunction(projectId.param, document)?.match(projectIdRegex)[0]
+    : undefined
+
+  return {
+    [name]: {
+      name,
+      host,
+      urlPatterns,
+      descriptionFormat,
+      queryFunctions,
+      allowHostOverride,
+      description: (document, service) => {
+        let params = {}
+        urlParams.forEach((value) => (params = { ...params, [value]: service[value] }))
+        return getDescription(service, service.queryFunctions, document, params)
+      },
+      ...{ projectId },
+    },
+  }
+}
+
+export function customPatterReader() {
+  return json.map((entry) => {
+    const queryFunctions = []
+    const urlParams = []
+
+    entry.query.forEach((query) => {
+      if (query.type === "FIELD_IDENTIFIER") {
+        buildQuerySelector(query, queryFunctions)
+      }
+      if (query.type === "URL_PARAM") {
+        urlParams.push(query.selector)
+      }
+    })
+
+    let projectId = entry.query.find((value) => value.name === "projectId")
+    projectId = projectId ? queryFunctions.find((value) => value.name === "projectId") : undefined
+
+    return buildService(
+      entry.name,
+      entry.host,
+      entry.urlPatterns,
+      entry.descriptionFormat,
+      entry.allowHostOverride,
+      queryFunctions,
+      urlParams,
+      projectId,
+    )
+  })
+}

--- a/src/js/test.json
+++ b/src/js/test.json
@@ -1,0 +1,80 @@
+[
+  {
+    "name": "testGitlab",
+    "host": "https://gitlab.com",
+    "urlPatterns": [
+      ":host:/test/customers/testcustomer/testprojekt/-/issues/:id"
+    ],
+    "query": [
+      {
+        "name": "title",
+        "type": "FIELD_IDENTIFIER",
+        "selector": "#content-body > div.issue-details.issuable-details > div.detail-page-description.content-block > div:nth-child(1) > div > div.title-container > h2"
+      },
+      {
+        "name": "projectId",
+        "type": "FIELD_IDENTIFIER",
+        "selector": "#content-body > div.issue-details.issuable-details > div.detail-page-description.content-block > div:nth-child(1) > div > div.description.js-task-list-container.is-task-list-enabled > div.md > p:nth-child(2) > em"
+      },
+      {
+        "name": "id",
+        "type": "URL_PARAM",
+        "selector": "id"
+      }
+    ],
+    "allowHostOverride": true,
+    "descriptionFormat": "#:id :title"
+  },
+  {
+    "name": "testAtlassianRapidBoard",
+    "host": "https://test.atlassian.net",
+    "urlPatterns": [
+      ":host:/secure/RapidBoard.jspa"
+    ],
+    "query": [
+      {
+        "name": "title",
+        "type": "FIELD_IDENTIFIER",
+        "selector": "#jira > div.atlaskit-portal-container > div:nth-child(3) > div > div:nth-child(3) > div.css-yo0qgw.e1pwmxs01 > div > div > div.sc-dtPURA.dCshqi > div > div > div.sc-dpzcke.ihqNRO > div > div.sc-lEDTX.gMkILc > div.sc-ciodno.bVflpV > div > div.sc-dZWBBA.eHznEF > div > div.sc-doUfgd.bFYaur > div > div > div > div.ContentWrapper-kdagst-0.fPLsyX > div > div > div > div > div > h1"
+      },
+      {
+        "name": "projectId",
+        "type": "FIELD_IDENTIFIER",
+        "selector": "#jira > div.atlaskit-portal-container > div:nth-child(3) > div > div:nth-child(3) > div.css-yo0qgw.e1pwmxs01 > div > div > div.sc-dtPURA.dCshqi > div > div > div.sc-dpzcke.ihqNRO > div > div.sc-lEDTX.gMkILc > div.sc-ciodno.bVflpV > div > div.sc-dZWBBA.gNupAy > div > div > div:nth-child(2) > div.sc-eEOpXj.VIXAL > div:nth-child(6) > div.sc-bscRGj.LgXZm > div > div > div.ContentWrapper-kdagst-0.fPLsyX > div > div > div > div > div > div"
+      },
+      {
+        "name": "id",
+        "type": "FIELD_IDENTIFIER",
+        "selector": "#jira-issue-header > div > div > div > div > div > div > div.sc-guztPN.gimUyy.sc-fCPvlr.ePPaTc > div > div > div > div:nth-child(1) > div > div > a > span > span"
+      }
+    ],
+    "allowHostOverride": true,
+    "descriptionFormat": "#:id :title"
+  },
+  {
+    "name": "testAtlassianBrowse",
+    "host": "https://test.atlassian.net",
+    "urlPatterns": [
+      ":host:/browse/:id"
+    ],
+    "query": [
+      {
+        "name": "title",
+        "type": "FIELD_IDENTIFIER",
+        "selector": "#helpPanelContainer > div > div > div.css-e48442 > div.sc-jWBwVP.lcvVTX > div > div.sc-bHwgHz.dkHycT > div.sc-cMOKGX.ghLXmN > div > div.sc-hLYIQQ.dwakSn > div.sc-dUjcNx.ihAcrP > div > div.sc-cROsgo.fsrnXA > div > div.sc-fXchrD.dhvDUL > div > div > div > div.ContentWrapper-kdagst-0.fPLsyX > div > div > div > div > div > h1"
+      },
+      {
+        "name": "projectId",
+        "type": "FIELD_IDENTIFIER",
+        "selector": "#helpPanelContainer > div > div > div.css-e48442 > div.sc-jWBwVP.lcvVTX > div > div.sc-bHwgHz.dkHycT > div.sc-cMOKGX.ghLXmN > div > div.sc-hLYIQQ.dwakSn > div.sc-dUjcNx.ihAcrP > div > div.sc-cROsgo.krYqOq > div > div.sc-ksfqlt.bnzHCu > div:nth-child(2) > div.sc-dUZuEM.fgULcy > div:nth-child(6) > div.sc-hvvHee.gkDrJu > div > div > div.ContentWrapper-kdagst-0.fPLsyX > div > div > div > div > div > div"
+      },
+      {
+        "name": "id",
+        "type": "URL_PARAM",
+        "selector": "id"
+      }
+    ],
+    "allowHostOverride": true,
+    "descriptionFormat": "#:id :title"
+  }
+]

--- a/src/js/utils/messageHandlers.js
+++ b/src/js/utils/messageHandlers.js
@@ -11,11 +11,16 @@ import { get, forEach, reject, isNil } from "lodash/fp"
 import { createMatcher } from "utils/urlMatcher"
 import remoteServices from "remoteServices"
 import { queryTabs, isBrowserTab, getSettings, setStorage } from "utils/browser"
+import { customPatterReader } from "../customPattern"
 
 let matcher
 
 const initMatcher = (settings) => {
-  matcher = createMatcher(remoteServices, settings.hostOverrides)
+  let services = remoteServices
+  customPatterReader().forEach((entry) => {
+    services = { ...entry, ...services }
+  })
+  matcher = createMatcher(services, settings.hostOverrides)
 }
 
 getSettings().then((settings) => {

--- a/test/utils/urlMatcher.test.js
+++ b/test/utils/urlMatcher.test.js
@@ -1,12 +1,17 @@
 import remoteServices from "../../src/js/remoteServices"
 import { createMatcher, createEnhancer } from "../../src/js/utils/urlMatcher"
+import { customPatterReader } from "../../src/js/customPattern"
 
 describe("utils", () => {
   describe("urlMatcher", () => {
     let matcher
 
     beforeEach(() => {
-      matcher = createMatcher(remoteServices, {})
+      let services = remoteServices
+      customPatterReader().forEach((entry) => {
+        services = { ...entry, ...services }
+      })
+      matcher = createMatcher(services, {})
     })
 
     describe("createMatcher", () => {


### PR DESCRIPTION
This is an Implementation for https://github.com/hundertzehn/mocoapp-browser-extension/issues/180

A JSON format is used to create the possibility to connect your own services and fields to the plugin.

It is not yet clear how the JSON can be provided.
Possible would be:
- provide a self-hosted JSON and announce the url in the plugin via the settings
- the moco site offers the possibility for all employees to create such a structure
- in the plugin via a UI field in the settings to define the structure

As this is still open, the MR does not yet offer any improvement over the previous solution and should therefore be regarded as a proposal for further development.