### PR TITLE
Add GitLab folder support

### DIFF
--- a/src/js/remoteServices.js
+++ b/src/js/remoteServices.js
@@ -158,10 +158,10 @@ export default {
     name: "gitlab",
     host: "https://gitlab.com",
     urlPatterns: [
-      ":host:/:org/:group/:projectId/-/issues/:id",
-      ":host:/:org/:projectId/-/issues/:id",
-      ":host:/:org/:group/:projectId/-/merge_requests/:id",
-      ":host:/:org/:projectId/-/merge_requests/:id",
+      ":host:/:org/:group(/*)/:projectId/-/issues/:id",
+      ":host:/:org(/*)/:projectId/-/issues/:id",
+      ":host:/:org/:group(/*)/:projectId/-/merge_requests/:id",
+      ":host:/:org(/*)/:projectId/-/merge_requests/:id",
     ],
     description: (document, service, { id }) => {
       const title = document.querySelector("h2.title")?.textContent?.trim()

--- a/test/utils/urlMatcher.test.js
+++ b/test/utils/urlMatcher.test.js
@@ -118,9 +118,20 @@ describe("utils", () => {
         expect(service.name).toEqual("gitlab")
         expect(service.projectId).toEqual("testproject")
       })
+
       it("should match gitlab-mergerequest url with group", () => {
         const service = matcher(
           "https://gitlab.com/testorganisatzion/test-group/testproject/-/merge_requests/1",
+        )
+        expect(service.id).toEqual("1")
+        expect(service.match.id).toEqual("1")
+        expect(service.name).toEqual("gitlab")
+        expect(service.projectId).toEqual("testproject")
+      })
+
+      it("should match gitlab-mergerequest url with group and folder", () => {
+        const service = matcher(
+          "https://gitlab.com/testorganisatzion/test-group/folder/foldertwo/testproject/-/merge_requests/1",
         )
         expect(service.id).toEqual("1")
         expect(service.match.id).toEqual("1")
@@ -139,6 +150,16 @@ describe("utils", () => {
       it("should match gitlab-issue url with group", () => {
         const service = matcher(
           "https://gitlab.com/testorganisatzion/test-group/testproject/-/issues/1",
+        )
+        expect(service.id).toEqual("1")
+        expect(service.match.id).toEqual("1")
+        expect(service.name).toEqual("gitlab")
+        expect(service.projectId).toEqual("testproject")
+      })
+
+      it("should match gitlab-issue url with group and folder", () => {
+        const service = matcher(
+          "https://gitlab.com/testorganisatzion/test-group/folder/fodldertwo/folderthree/testproject/-/issues/1",
         )
         expect(service.id).toEqual("1")
         expect(service.match.id).toEqual("1")


### PR DESCRIPTION
[Optional Wildcard Section](https://www.npmjs.com/package/url-pattern#optional-segments-wildcards-and-escaping) to allow GitLab folder structures

Bug fix for https://github.com/hundertzehn/mocoapp-browser-extension/issues/288