### PR TITLE
Reduced the popup's top padding.

### DIFF
--- a/src/css/content.scss
+++ b/src/css/content.scss
@@ -66,7 +66,7 @@
   .moco-bx-popup {
     position: fixed;
     z-index: 2000;
-    padding-top: 100px;
+    padding-top: 5vh;
     left: 0;
     top: 0;
     width: 100%;


### PR DESCRIPTION
I have a rather small laptop screen and when opening the Moco popup, I cannot submit my time, because the button is hidden. This PR fixes this behavior by reducing the top padding and making it relative to the screen's height. Here are screenshots of before and after the change.
Before:
![moco_before](https://user-images.githubusercontent.com/14217185/117427056-e922fd80-af24-11eb-9f44-f7ef787d8ed7.png)

After:
![moco_after](https://user-images.githubusercontent.com/14217185/117427107-f7711980-af24-11eb-909a-0d03a4fa4b86.png)
