### PR TITLE
Fix fetching description for basecamp3

### DIFF
--- a/src/js/remoteServices.js
+++ b/src/js/remoteServices.js
@@ -191,7 +191,8 @@ export default {
     name: "basecamp3",
     host: "https://3.basecamp.com",
     urlPatterns: [":host:/:instanceId/buckets/:projectId/todos/:id"],
-    description: (document) => document.head.querySelector(`meta[name='${name}']`)?.content,
+    description: (document) =>
+      document.head.querySelector("meta[name='current-recording-title']")?.content,
     projectId: projectIdentifierBySelector('meta[name="current-bucket-name"]', "content"),
     allowHostOverride: true,
   },


### PR DESCRIPTION
Thank you for merging #407! However, when refactoring my code, you introduced a small, but impactful issue here:
```javascript
description: (document) => document.head.querySelector(`meta[name='${name}']`)?.content,
```
You forgot to re-insert the name parameter. It should be this:
```javascript
description: (document) => document.head.querySelector("meta[name='current-recording-title']")?.content,
```