### PR TITLE
Make basecamp3 more generally usable

### DIFF
--- a/src/js/remoteServices.js
+++ b/src/js/remoteServices.js
@@ -190,7 +190,7 @@ export default {
   basecamp3: {
     name: "basecamp3",
     host: "https://3.basecamp.com",
-    urlPatterns: [":host:/:instanceId/buckets/:projectId/todos/:id"],
+    urlPatterns: [":host:/:instanceId/buckets/:projectId/:bucketType/:id"],
     description: (document) => document.head.querySelector(`meta[name='${name}']`)?.content,
     projectId: projectIdentifierBySelector('meta[name="current-bucket-name"]', "content"),
     allowHostOverride: true,


### PR DESCRIPTION
While implementing basecamp3-event, I noticed that a far simpler solution would be to refactor the urlPattern to apply to all types of objects in basecamp (which basecamp apparently calls 'buckets').

Using this, users can use the extension to track time on e.g. todos, events or documents. This offers maximum flexibility while also being completely safe because _every_ bucket provides a description using the same meta tag.