### PR TITLE
[FIX] GitLab issue/merge-request title selector

### DIFF
--- a/src/js/remoteServices.js
+++ b/src/js/remoteServices.js
@@ -172,7 +172,7 @@ export default {
       ":host:/:org(/*)/:projectId/-/merge_requests/:id",
     ],
     description: (document, service, { id }) => {
-      const title = document.querySelector("h2.title")?.textContent?.trim()
+      const title = document.querySelector('.detail-page-description .title')?.textContent?.trim()
       return `#${id} ${title || ""}`.trim()
     },
     allowHostOverride: true,


### PR DESCRIPTION
GitLab now uses h1 for issue titles, but still h2 for merge requests. Selfhosted or/and older instances may still use h2 on issue pages.

resolves #484