### PR TITLE
Add card url to basecamp3 service

### DIFF
--- a/src/js/remoteServicesCommunity.js
+++ b/src/js/remoteServicesCommunity.js
@@ -30,7 +30,10 @@ export default {
   basecamp3: {
     name: "basecamp3",
     host: "https://3.basecamp.com",
-    urlPatterns: [":host:/:instanceId/buckets/:projectId/:bucketType/:id"],
+    urlPatterns: [
+      ":host:/:instanceId/buckets/:projectId/:bucketType/:id",
+      ":host:/:instanceId/buckets/:projectId/:bucketType/cards/:id",
+    ],
     description: (document) =>
       document.head.querySelector("meta[name='current-recording-title']")?.content,
     projectId: projectIdentifierBySelector('meta[name="current-bucket-name"]', "content"),


### PR DESCRIPTION
Basecamp recently added [Card Tables](https://updates.37signals.com/post/new-in-basecamp-card-tables), which requires a new url pattern in the service configuration.