### PR TITLE
Add awork as community service

### DIFF
--- a/src/js/remoteServicesCommunity.js
+++ b/src/js/remoteServicesCommunity.js
@@ -132,7 +132,7 @@ export default {
 
       return [projectName, taskName].filter(p => p).join(' - ');
     },
-    allowHostOverride: true,
+    allowHostOverride: false,
     position: { right: "10px", bottom: "90px" },
   },
 }

--- a/src/js/remoteServicesCommunity.js
+++ b/src/js/remoteServicesCommunity.js
@@ -82,4 +82,57 @@ export default {
     allowHostOverride: true,
     position: { left: "calc(2rem + 5px)" },
   },
+
+  awork: {
+    name: "awork",
+    host: "https://:org.awork.io",
+    urlPatterns: [
+      ":host:/projects/:id/details",
+      ":host:/projects/:id/tasks/list",
+      ":host:/projects/:id/tasks/board",
+      ":host:/projects/:id/tasks/timeline",
+      ":host:/projects/:id/times/list",
+      ":host:/projects/:projectId/tasks/list/\\(detail\\::id/details\\)",
+      ":host:/projects/:projectId/tasks/board/\\(modal\\::id/details\\)",
+      ":host:/projects/:projectId/tasks/timeline/\\(detailModal\\::id/details\\)",
+      ":host:/tasks/:id/details",
+      ":host:/tasks/filters/\\(detail\\::id/details\\)",
+    ],
+    projectLabel: (document) => {
+      var names = {
+        projectNameFromProjectDetail: document
+          .querySelector("aw-project-detail #projectName textarea")
+          ?.value,
+        projectNameFromEntityDetail: document
+          .querySelector("aw-header-navigation-history div.main div.entity-details.project")
+          ?.textContent,
+      }
+
+      return (names.projectNameFromProjectDetail || names.projectNameFromEntityDetail || "").trim();
+    },
+    description: (document, service, { org, projectId, id }) => {
+      var names = {
+        projectNameFromProjectDetail: document
+          .querySelector("aw-project-detail #projectName textarea")
+          ?.value,
+        projectNameFromEntityDetail: document
+          .querySelector("aw-header-navigation-history div.main div.entity-details.project")
+          ?.textContent,
+        
+        taskNameFromTaskDetail: document
+          .querySelector("aw-task-detail h1 textarea")
+          ?.value,
+        taskNameFromEntityDetail: document
+          .querySelector("aw-header-navigation-history div.main div.entity-details.task")
+          ?.textContent,  
+      }
+
+      var projectName = (names.projectNameFromProjectDetail || names.projectNameFromEntityDetail || "").trim();
+      var taskName = (names.taskNameFromTaskDetail || names.taskNameFromEntityDetail || "").trim();
+
+      return [projectName, taskName].filter(p => p).join(' - ');
+    },
+    allowHostOverride: true,
+    position: { right: "10px", bottom: "90px" },
+  },
 }

--- a/src/js/remoteServicesCommunity.js
+++ b/src/js/remoteServicesCommunity.js
@@ -92,45 +92,44 @@ export default {
       ":host:/projects/:id/tasks/board",
       ":host:/projects/:id/tasks/timeline",
       ":host:/projects/:id/times/list",
-      ":host:/projects/:projectId/tasks/list/\\(detail\\::id/details\\)",
-      ":host:/projects/:projectId/tasks/board/\\(modal\\::id/details\\)",
-      ":host:/projects/:projectId/tasks/timeline/\\(detailModal\\::id/details\\)",
+      ":host:/projects/:project/tasks/list/\\(detail\\::id/details\\)",
+      ":host:/projects/:project/tasks/board/\\(modal\\::id/details\\)",
+      ":host:/projects/:project/tasks/timeline/\\(detailModal\\::id/details\\)",
       ":host:/tasks/:id/details",
       ":host:/tasks/filters/\\(detail\\::id/details\\)",
     ],
+    projectId: (document) => {
+      const projectId =
+        projectIdentifierBySelector("aw-project-detail #projectName textarea", "value")(document) ||
+        projectIdentifierBySelector(
+          "aw-header-navigation-history div.main div.entity-details.project",
+          "textContent",
+        )(document)
+      return projectId || ""
+    },
     projectLabel: (document) => {
-      var names = {
-        projectNameFromProjectDetail: document
-          .querySelector("aw-project-detail #projectName textarea")
-          ?.value,
-        projectNameFromEntityDetail: document
-          .querySelector("aw-header-navigation-history div.main div.entity-details.project")
-          ?.textContent,
-      }
+      const projectName =
+        document.querySelector("aw-project-detail #projectName textarea")?.value ||
+        document.querySelector("aw-header-navigation-history div.main div.entity-details.project")
+          ?.textContent
 
-      return (names.projectNameFromProjectDetail || names.projectNameFromEntityDetail || "").trim();
+      return (projectName || "").trim()
     },
     description: (document, service, { org, projectId, id }) => {
-      var names = {
-        projectNameFromProjectDetail: document
-          .querySelector("aw-project-detail #projectName textarea")
-          ?.value,
-        projectNameFromEntityDetail: document
-          .querySelector("aw-header-navigation-history div.main div.entity-details.project")
-          ?.textContent,
-        
-        taskNameFromTaskDetail: document
-          .querySelector("aw-task-detail h1 textarea")
-          ?.value,
-        taskNameFromEntityDetail: document
-          .querySelector("aw-header-navigation-history div.main div.entity-details.task")
-          ?.textContent,  
-      }
+      let projectName =
+        document.querySelector("aw-project-detail #projectName textarea")?.value ||
+        document.querySelector("aw-header-navigation-history div.main div.entity-details.project")
+          ?.textContent
 
-      var projectName = (names.projectNameFromProjectDetail || names.projectNameFromEntityDetail || "").trim();
-      var taskName = (names.taskNameFromTaskDetail || names.taskNameFromEntityDetail || "").trim();
+      let taskName =
+        document.querySelector("aw-task-detail h1 textarea")?.value ||
+        document.querySelector("aw-header-navigation-history div.main div.entity-details.task")
+          ?.textContent
 
-      return [projectName, taskName].filter(p => p).join(' - ');
+      projectName = (projectName || "").trim()
+      taskName = (taskName || "").trim()
+
+      return [projectName, taskName].filter((p) => p).join(" - ")
     },
     allowHostOverride: false,
     position: { right: "10px", bottom: "90px" },


### PR DESCRIPTION
This PR implements awork as a community service. Would appreciate a review and I am also open to any feedbacks!

I have a question:

- I am using awork's entity id (which is a Guid) as projectId, therefore awork Ids will surely not match MOCO's. But, does MOCO do some cross id matching internally, or should I simply return :projectId from the URLs entirely and attempt to use something from the DOM instead?

Thanks!