### PR TITLE
Improve awork community service

### DIFF
--- a/src/js/remoteServicesCommunity.js
+++ b/src/js/remoteServicesCommunity.js
@@ -88,11 +88,6 @@ export default {
     name: "awork",
     host: "https://:org.awork.com",
     urlPatterns: [
-      ":host:/projects/:id/details",
-      ":host:/projects/:id/tasks/list",
-      ":host:/projects/:id/tasks/board",
-      ":host:/projects/:id/tasks/timeline",
-      ":host:/projects/:id/times/list",
       ":host:/projects/:project/tasks/list/\\(detail\\::id/details\\)",
       ":host:/projects/:project/tasks/board/\\(modal\\::id/details\\)",
       ":host:/projects/:project/tasks/timeline/\\(detailModal\\::id/details\\)",
@@ -106,7 +101,15 @@ export default {
           "aw-header-navigation-history div.main div.entity-details.project",
           "textContent",
         )(document)
-      return projectId || ""
+
+      const taskId =
+        projectIdentifierBySelector("aw-task-detail h1 textarea", "value")(document) ||
+        projectIdentifierBySelector(
+          "aw-header-navigation-history div.main div.entity-details.task",
+          "textContent",
+        )(document)
+
+      return projectId || taskId || ""
     },
     projectLabel: (document) => {
       const projectName =
@@ -114,7 +117,12 @@ export default {
         document.querySelector("aw-header-navigation-history div.main div.entity-details.project")
           ?.textContent
 
-      return (projectName || "").trim()
+      const taskName =
+        document.querySelector("aw-task-detail h1 textarea")?.value ||
+        document.querySelector("aw-header-navigation-history div.main div.entity-details.task")
+          ?.textContent
+
+      return (projectName || taskName || "").trim()
     },
     description: (document, _service, { org: _org, projectId: _projectId, id: _id }) => {
       let projectName =


### PR DESCRIPTION
A few improvements to awork community service based on feedback we received:

- no more logging time on projects - this was causing confusion due to the way our hierarchy works (project, task, subtask). Now we only allow logging time on tasks and subtasks
- better project id matching - try to look for project identifier on task name as well
- project label fallback on task - as a fallback, set the project label as task name if the project name is not available (private tasks)

Thank you, once again, for the help and support from MOCO's team!