### PR TITLE
Add remoteService Superchat

### DIFF
--- a/src/js/remoteServicesCommunity.js
+++ b/src/js/remoteServicesCommunity.js
@@ -161,36 +161,27 @@ export default {
     urlPatterns: [":host:/inbox/:id"],
     id: (document, service, { id }) => [service.key, id].join("."),
     description: (document, _service, { id }) => {
-      var subjectsRaw =   document.querySelectorAll("div#__next div div#bodySafeArea  h4.hy-font-semibold.hy-text-sm.hy-mt-6.hy-px-6.hy-cursor-pointer")
-      var subject = id.toString()
+      let subjectsRaw =   document.querySelectorAll("div#__next div div#bodySafeArea  h4.hy-font-semibold.hy-text-sm.hy-mt-6.hy-px-6.hy-cursor-pointer")
+      let subject = id.toString()
       if(subjectsRaw.length == 1){
-        var subjectRaw = subjectsRaw[0].innerHTML
+        let subjectRaw = subjectsRaw[0].innerHTML
         subject = subjectRaw.substring(subjectRaw.indexOf(":")+2)
-      }else{
-        console.debug("subject field not found:")
-        console.debug(subjectsRaw)
       }
 
-      var contactNameFields = document.querySelectorAll("div#__next div#bodySafeArea div.font-semibold.cursor-pointer.text-hy-black.text-hy-base.whitespace-nowrap.truncate.mr-2")
-      var contactName = ""
+      let contactNameFields = document.querySelectorAll("div#__next div#bodySafeArea div.font-semibold.cursor-pointer.text-hy-black.text-hy-base.whitespace-nowrap.truncate.mr-2")
+      let contactName = ""
       if(contactNameFields.length == 1){
         contactName = contactNameFields[0].title
-      }else{
-        console.debug("contactName field not found:")
-        console.debug(contactNameFields)
       }
-      
-      var desc = subject + " | " + contactName
+
+      let desc = subject + " | " + contactName
       return desc
     },
     projectId: (document) => {
-      var projectId = ""
-      var projectLabels = document.querySelectorAll("div#__next  div#bodySafeArea span[title='Moco ProjectId']")
+      let projectId = ""
+      let projectLabels = document.querySelectorAll("div#__next  div#bodySafeArea span[title='Moco ProjectId']")
       if(projectLabels.length == 1){
         projectId = projectLabels[0].parentElement.parentElement.nextElementSibling.querySelector("input").value 
-      }else{
-        console.debug("projectLabel field not found:")
-        console.debug(projectLabels)
       }
 
       return projectId

--- a/src/js/remoteServicesCommunity.js
+++ b/src/js/remoteServicesCommunity.js
@@ -155,4 +155,46 @@ export default {
     },
     allowHostOverride: false,
   },
+  superchat: {
+    name: "superchat",
+    host: "https://app.superchat.de",
+    urlPatterns: [":host:/inbox/:id"],
+    id: (document, service, { id }) => [service.key, id].join("."),
+    description: (document, _service, { id }) => {
+      var subjectsRaw =   document.querySelectorAll("div#__next div div#bodySafeArea  h4.hy-font-semibold.hy-text-sm.hy-mt-6.hy-px-6.hy-cursor-pointer")
+      var subject = id.toString()
+      if(subjectsRaw.length == 1){
+        var subjectRaw = subjectsRaw[0].innerHTML
+        subject = subjectRaw.substring(subjectRaw.indexOf(":")+2)
+      }else{
+        console.debug("subject field not found:")
+        console.debug(subjectsRaw)
+      }
+
+      var contactNameFields = document.querySelectorAll("div#__next div#bodySafeArea div.font-semibold.cursor-pointer.text-hy-black.text-hy-base.whitespace-nowrap.truncate.mr-2")
+      var contactName = ""
+      if(contactNameFields.length == 1){
+        contactName = contactNameFields[0].title
+      }else{
+        console.debug("contactName field not found:")
+        console.debug(contactNameFields)
+      }
+      
+      var desc = subject + " | " + contactName
+      return desc
+    },
+    projectId: (document) => {
+      var projectId = ""
+      var projectLabels = document.querySelectorAll("div#__next  div#bodySafeArea span[title='Moco ProjectId']")
+      if(projectLabels.length == 1){
+        projectId = projectLabels[0].parentElement.parentElement.nextElementSibling.querySelector("input").value 
+      }else{
+        console.debug("projectLabel field not found:")
+        console.debug(projectLabels)
+      }
+
+      return projectId
+    },
+    allowHostOverride: false,
+  },
 }


### PR DESCRIPTION
Hi,

this PR adds the system "Superchat" as a community service.

The frontend unfortunately doesn't have easily distinct HTML structures, which could cause the CSS selectors to break easily.
Superchat offers an API, and in the future, we might consider retrieving data from Superchat via this API. Could we add an extra section in the options for external API keys and then implement the interfaces in the service worker, or would that no longer be desired for the extension?

Best regards
Niklas