### PR TITLE
Update Node.js version in .nvmrc to lts/iron

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+lts/iron


### PR DESCRIPTION
The previously configured Node.js version (16.x) was outdated and incompatible with some dependencies requiring Node.js 18.x or higher. This update aligns the environment with the latest LTS (lts/iron) to ensure compatibility and stability.