### PR TITLE
feat: add Redmine support

### DIFF
--- a/src/js/remoteServices.js
+++ b/src/js/remoteServices.js
@@ -154,6 +154,20 @@ export default {
     allowHostOverride: false,
   },
 
+  redmine: {
+    name: "redmine",
+    host: "", // No central cloud hosting, so no host by default
+    urlPatterns: [":host:/issues/:id"],
+    description: (document, _service, { title }) => {
+      const issueIdMatch = window.location.href.match(/\/issues\/(\d+)(\?.*)?$/)
+      const issueId = issueIdMatch ? issueIdMatch[1] : null
+      const issueTitle = document.querySelector(".subject>div>h3")?.textContent?.trim() || title
+      return issueId ? `${issueId}: ${issueTitle}` : issueTitle
+    },
+    projectId: (document) => projectIdentifierBySelector(".current-project")(document),
+    allowHostOverride: true,
+  },
+
   trello: {
     name: "trello",
     host: "https://trello.com",

--- a/src/js/remoteServices.js
+++ b/src/js/remoteServices.js
@@ -154,20 +154,6 @@ export default {
     allowHostOverride: false,
   },
 
-  redmine: {
-    name: "redmine",
-    host: "", // No central cloud hosting, so no host by default
-    urlPatterns: [":host:/issues/:id"],
-    description: (document, _service, { title }) => {
-      const issueIdMatch = window.location.href.match(/\/issues\/(\d+)(\?.*)?$/)
-      const issueId = issueIdMatch ? issueIdMatch[1] : null
-      const issueTitle = document.querySelector(".subject>div>h3")?.textContent?.trim() || title
-      return issueId ? `${issueId}: ${issueTitle}` : issueTitle
-    },
-    projectId: (document) => projectIdentifierBySelector(".current-project")(document),
-    allowHostOverride: true,
-  },
-
   trello: {
     name: "trello",
     host: "https://trello.com",

--- a/src/js/remoteServicesCommunity.js
+++ b/src/js/remoteServicesCommunity.js
@@ -197,4 +197,19 @@ export default {
     },
     allowHostOverride: false,
   },
+
+  // redmine service config provided by zeroseven (@pdaether)
+  redmine: {
+    name: "redmine",
+    host: "", // No central cloud hosting, so no host by default
+    urlPatterns: [":host:/issues/:id"],
+    description: (document, _service, { title }) => {
+      const issueIdMatch = window.location.href.match(/\/issues\/(\d+)(\?.*)?$/)
+      const issueId = issueIdMatch ? issueIdMatch[1] : null
+      const issueTitle = document.querySelector(".subject>div>h3")?.textContent?.trim() || title
+      return issueId ? `${issueId}: ${issueTitle}` : issueTitle
+    },
+    projectId: (document) => projectIdentifierBySelector(".current-project")(document),
+    allowHostOverride: true,
+  },
 }


### PR DESCRIPTION
- Default host is left empty since Redmine lacks an official cloud version.
- Tested with Redmine major versions 5 and 6 (latest).