### PR TITLE
Update Asana CSS-Selector for H1

### DIFF
--- a/src/js/remoteServices.js
+++ b/src/js/remoteServices.js
@@ -19,7 +19,7 @@ export default {
     },
     description: (document) => document.querySelector(".TitleInput textarea")?.textContent?.trim(),
     projectId: projectIdentifierBySelector(
-      ".TopbarPageHeaderStructureWithBreadcrumbs-titleAndBreadcrumbs h1",
+      ".PageHeader h1",
     ),
     allowHostOverride: false,
     position: { right: "50%", transform: "translateX(50%)" },


### PR DESCRIPTION
Asana has once again changed the CSS selectors in the header area, so automatic project ID detection no longer works.

This merge request fixes that.