### PR TITLE
Support GitLab work item URLs for time booking

### DIFF
--- a/src/js/remoteServicesCommunity.js
+++ b/src/js/remoteServicesCommunity.js
@@ -7,11 +7,22 @@ export default {
     urlPatterns: [
       ":host:/:org/:group(/*)/:projectId/-/issues/:id(#note_:noteId)",
       ":host:/:org(/*)/:projectId/-/issues/:id(#note_:noteId)",
+      ":host:/:org/:group(/*)/:projectId/-/work_items/:id(#note_:noteId)",
+      ":host:/:org(/*)/:projectId/-/work_items/:id(#note_:noteId)",
       ":host:/:org/:group(/*)/:projectId/-/merge_requests/:id(#note_:noteId)",
       ":host:/:org(/*)/:projectId/-/merge_requests/:id(#note_:noteId)",
     ],
     description: (document, service, { id, noteId: _noteId }) => {
-      const title = document.querySelector("h1")?.textContent?.trim()
+      const titleFromDocument = document.title?.trim()
+      const titleSuffix = " · GitLab"
+      const title =
+        document.querySelector("h1")?.textContent?.trim() ||
+        document
+          .querySelector('[data-testid="work-item-title"], [data-testid="issue-title"]')
+          ?.textContent?.trim() ||
+        (titleFromDocument?.endsWith(titleSuffix)
+          ? titleFromDocument.slice(0, -titleSuffix.length).trim()
+          : titleFromDocument)
       return `#${id} ${title || ""}`.trim()
     },
     allowHostOverride: true,

--- a/test/utils/urlMatcher.test.js
+++ b/test/utils/urlMatcher.test.js
@@ -223,6 +223,34 @@ describe("utils", () => {
         expect(service.noteId).toEqual("87285")
       })
 
+      it.each([
+        {
+          label: "url",
+          url: "https://gitlab.com/testorganisatzion/testproject/-/work_items/1",
+          projectId: "testproject",
+        },
+        {
+          label: "url with note anchor",
+          url: "https://gitlab.com/testorganisatzion/testproject/-/work_items/1#note_85524",
+          projectId: "testproject",
+          noteId: "85524",
+        },
+        {
+          label: "url with group and folder",
+          url: "https://gitlab.com/testorganisatzion/test-group/folder/fodldertwo/folderthree/testproject/-/work_items/1",
+          projectId: "testproject",
+        },
+      ])("should match gitlab-work-item $label", ({ url, projectId, noteId }) => {
+        const service = matcher(url)
+        expect(service.id).toEqual("1")
+        expect(service.match.id).toEqual("1")
+        expect(service.name).toEqual("gitlab")
+        expect(service.projectId).toEqual(projectId)
+        if (noteId) {
+          expect(service.noteId).toEqual(noteId)
+        }
+      })
+
       it("should match asana urls", () => {
         let service
         service = matcher("https://app.asana.com/0/inbox/123/675/890")


### PR DESCRIPTION
GitLab now exposes some issue pages under /-/work_items/... instead of /-/issues/.... The extension only matched the legacy issue URLs, so MOCO could not detect the related GitLab item and booking time from those pages stopped working.

Add GitLab work item URL patterns, keep the title lookup compatible with the newer page variant, and cover the new matcher behavior with regression tests.

<img width="1627" height="1256" alt="work-item-example" src="https://github.com/user-attachments/assets/90c4948c-b720-4895-8215-423a4c1d5e83" />
