### PR TITLE
Add Notion service integration

### DIFF
--- a/src/js/remoteServicesCommunity.js
+++ b/src/js/remoteServicesCommunity.js
@@ -248,5 +248,29 @@ export default {
     },
     projectId: (document) => projectIdentifierBySelector(".project-item span:nth-child(2)")(document),
     allowHostOverride: false,
-  }
+  },
+
+  notion: {
+    name: "notion",
+    host: "https://app.notion.com",
+    urlPatterns: [":host:/p/:workspace/*"],
+    queryParams: {
+      id: "p",
+    },
+    id: (_document, _service, { id, _: slug }) => {
+      if (id) return id
+      const slugMatch = slug?.match(/-([a-f0-9]{32})$/)
+      return slugMatch ? slugMatch[1] : null
+    },
+    description: (document, _service, { id }) => {
+      const h1s = Array.from(document.querySelectorAll("h1[contenteditable]")).filter(
+        (el) => el.textContent.trim(),
+      )
+      if (!h1s.length) return null
+      // In peek mode (id from ?p=) React renders the panel after the main page in the DOM
+      const h1 = id && h1s.length > 1 ? h1s[h1s.length - 1] : h1s[0]
+      return h1.textContent.trim()
+    },
+    allowHostOverride: false,
+  },
 }


### PR DESCRIPTION
## Summary

Adds time tracking support for `app.notion.com` pages.

**Supported URL patterns:**
- Direct page view: `/p/:workspace/:title-:pageId`
- Subpage in peek/panel view: `/p/:workspace/:parent?p=:pageId&pm=s`

**Title extraction:**
The page title is read from Notion's `h1[contenteditable]` element. In peek mode, React renders the panel's `h1` after the main page's `h1` in the DOM — so we select the last one when `id` is set via the `?p=` query param.

## Note for MOCO backend

`"notion"` needs to be added to the allowed `remote_service` values in the MOCO API for time logging to work.

## Test plan

- [ ] Open a direct Notion page (`/p/:workspace/:title-:id`) — bubble appears, title pre-filled
- [ ] Open a Notion page in peek/panel mode (`?p=:id`) — correct panel title used, not the background page title
- [ ] Log time / start stopwatch (requires `"notion"` whitelisted in MOCO backend)