### PR TITLE
Fix Notion remote URL, bubble position, and detail-page visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.18.2] – 2026-07-03
+
+### Fixed
+
+- Notion: use the page's stable permalink (`/p/:workspace/:id`) as the remote URL instead of the current tab URL, which can be a shared database view other users can't open
+- Notion: show the time-tracking bubble on a task's own detail page, not just in peek/preview mode
+
+### Changed
+
+- Notion: position the time-tracking bubble on the right edge, vertically centered
+
 ## [2.18.1] – 2026-07-01
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "moco-browser-extensions",
   "description": "Browser plugin for MOCO",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "license": "MIT",
   "browserslist": [
     "defaults",

--- a/src/js/remoteServicesCommunity.js
+++ b/src/js/remoteServicesCommunity.js
@@ -281,6 +281,11 @@ export default {
       const h1 = id && h1s.length > 1 ? h1s[h1s.length - 1] : h1s[0]
       return h1.textContent.trim()
     },
+    // The tab URL can be a shared database view that not all users have access to.
+    // The single-page permalink (built from workspace + page id) always works.
+    remoteUrl: (document, service, { workspace }, id) =>
+      workspace && id ? `${service.host}/p/${workspace}/${id}` : null,
     allowHostOverride: false,
+    position: { top: "50%", right: "5px", bottom: "auto", transform: "translateY(-50%)" },
   },
 }

--- a/src/js/utils/messageHandlers.js
+++ b/src/js/utils/messageHandlers.js
@@ -7,7 +7,7 @@ import {
   getStartOfWeek,
   getEndOfWeek,
 } from "utils"
-import { get, forEach, reject, isNil } from "lodash/fp"
+import { get, forEach, reject, isNil, isFunction } from "lodash/fp"
 import { createMatcher } from "utils/urlMatcher"
 import remoteServices from "remoteServices"
 import { sendMessage } from "webext-bridge/background"
@@ -18,10 +18,22 @@ const initMatcher = (settings) => {
   matcher = createMatcher(remoteServices, settings.hostOverrides)
 }
 
+// matched.id is either the raw url-pattern match (e.g. Notion's peek-mode
+// "?p=" query param) or, for services that define a custom id(), the
+// extractor function itself. Some extractors (e.g. Notion's slug-based
+// fallback for its full-page URLs) can only resolve an id this way, so the
+// raw match alone isn't enough to detect whether a service applies.
+function resolveServiceId(matched) {
+  if (!matched) {
+    return undefined
+  }
+  return isFunction(matched.id) ? matched.id(null, matched, matched.match) : matched.id
+}
+
 export async function tabUpdated(tab) {
   const settings = await getSettings()
   initMatcher(settings)
-  const hasService = matcher(tab.url)?.match?.id
+  const hasService = resolveServiceId(matcher(tab.url))
   const apiClient = new ApiClient(settings)
 
   if (hasService) {

--- a/src/js/utils/urlMatcher.js
+++ b/src/js/utils/urlMatcher.js
@@ -88,13 +88,19 @@ export const createEnhancer = (document) => (service) => {
   const args = [document, service, match]
   const evaluate = createEvaluator(args)
 
+  const id = evaluate(service.id)
+
   return {
     ...service,
-    id: evaluate(service.id),
+    id,
     description: evaluate(service.description),
     projectId: evaluate(service.projectId),
     projectLabel: evaluate(service.projectLabel),
     taskId: evaluate(service.taskId),
+    // Some services (e.g. Notion) can end up on a tab URL that is only valid for the
+    // current user (a shared view link). remoteUrl lets a service build a stable,
+    // shareable link instead of falling back to the raw tab URL.
+    url: (isFunction(service.remoteUrl) && service.remoteUrl(document, service, match, id)) || service.url,
     position: service.position || { right: "calc(2rem + 5px)" },
   }
 }


### PR DESCRIPTION
## Summary
- The Notion service stored the current tab URL as the remote link, which can be a shared database view that not all users have access to. Add a `remoteUrl` hook so a service can build a stable permalink (`/p/:workspace/:id`) instead.
- The time-tracking bubble only showed up in Notion's peek/preview mode. `tabUpdated` only checked the raw url-pattern id (populated via the `?p=` query param) and ignored a service's custom `id()` extractor, which is how Notion resolves the id on its full-page URLs. Fixed by evaluating the extractor when present.
- Position the Notion bubble on the right edge, vertically centered, 5px from the edge.

## Test plan
- [x] `yarn test` (50/50 passing)
- [x] `yarn build:chrome` builds successfully
- [ ] Manually verified in Chrome: bubble shows on both a Notion peek/preview and a task's own detail page, and the stored remote URL is the stable permalink